### PR TITLE
delete old backup chains before creating a new one to use less disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ disk = 'CHBackup'
 # a full backup will be created every time a chain has reached x incremental backups.
 max_incremental_backups = 6
 # keep 2 full backups by default + their incrementals
-# set to 0 to keep all backups
+# set to 0 to keep all backups.
+# backups are deleted before creation.
+# if set to 2 and a 3rd chain would be created -> deleted
+# if set to 1 and only 1 chain exists, the deletion is delayed to the next run
 max_full_backups = 2
 ```
 
@@ -124,6 +127,9 @@ ignored_databases = [
 max_incremental_backups = 6
 # keep 2 full backups by default + their incrementals
 # set to 0 to keep all backups
+# backups are deleted before creation.
+# if set to 2 and a 3rd chain would be created -> deleted
+# if set to 1 and only 1 chain exists, the deletion is delayed to the next run
 max_full_backups = 2
 
 [backup.s3]

--- a/src/clickhouse_backup/clickhouse/client.py
+++ b/src/clickhouse_backup/clickhouse/client.py
@@ -203,7 +203,6 @@ class Client:
         )
         logger.info(f'Creating a new backup: {backup}')
         result = self.client.execute(query + " ASYNC")
-        logger.info(f'Created backup: {backup}')
         (backup_id, status) = result[0]
         logger.info(f'Backup {backup_id} status: {status}')
         if status != 'CREATING_BACKUP':

--- a/src/clickhouse_backup/run.py
+++ b/src/clickhouse_backup/run.py
@@ -109,9 +109,7 @@ def clean_old_backups(existing_backups: Dict[datetime, FullBackup],
         if n == max_full_backups:
             if isinstance(next_backup, IncrementalBackup):
                 break
-        elif n == 1:
-            break
-        else:
+        elif n < max_full_backups:
             break
         x = existing_backups.pop(timestamp)
         logger.info(f'Deleting a full backup: {x} (Max {max_full_backups} full backups)')

--- a/src/clickhouse_backup/run.py
+++ b/src/clickhouse_backup/run.py
@@ -14,7 +14,7 @@ from loguru import logger
 from clickhouse_backup.clickhouse.client import BackupTarget, Client
 from clickhouse_backup.utils.config import parse_config
 from clickhouse_backup.utils.converters import parse_file_name
-from clickhouse_backup.utils.datatypes import FullBackup, IncrementalBackup
+from clickhouse_backup.utils.datatypes import Backup, FullBackup, IncrementalBackup
 from clickhouse_backup.utils.logging import setup_logging
 
 
@@ -88,19 +88,29 @@ def get_base_backup(existing_backups: Dict[datetime, FullBackup],
 
 
 def clean_old_backups(existing_backups: Dict[datetime, FullBackup],
-                      max_full_backups: int):
+                      max_full_backups: int,
+                      next_backup: Backup):
     """
     Remove old backup chains.
     If we have n > max_full_backups, the oldest full backup + its
     incremental backups are deleted.
+    If we have n >= max_full_backups and the next one is a full one, we
+    also wipe the chain.
     :param existing_backups: dict containing existing backups
     :param max_full_backups: max full backups to keep.
+    :param next_backup: next backup what will be created.
     :return:
     """
     if max_full_backups == 0:
         return
     for timestamp in sorted(existing_backups.keys()):
-        if len(existing_backups) <= max_full_backups:
+        n = len(existing_backups)
+        if n == max_full_backups:
+            if isinstance(next_backup, IncrementalBackup):
+                break
+        elif n == 1:
+            break
+        else:
             break
         x = existing_backups.pop(timestamp)
         logger.info(f'Deleting a full backup: {x} (Max {max_full_backups} full backups)')
@@ -179,6 +189,16 @@ def backup_command(
     new_backup = (base_backup.new_incremental_backup()
                   if base_backup
                   else FullBackup(backup_dir=args.ch.backup_dir))
+    if len(args.existing_backups) > 1:  # we will never delete if we only have 1 chain
+        try:
+            clean_old_backups(
+                args.existing_backups,
+                args.settings('backup.max_full_backups', cast=int, default=2),
+                new_backup
+            )
+        except Exception as e:
+            logger.error(f'Error while deleting backup: {e}')
+            sys.exit(1)
     try:
         args.ch.backup(
             backup=new_backup,
@@ -192,16 +212,6 @@ def backup_command(
     except Exception as e:
         logger.critical(f'Backup failed! (ClickHouse Error): {e}')
         sys.exit(1)
-
-    if len(args.existing_backups) > 1:  # we will never delete if we only have 1 chain
-        try:
-            clean_old_backups(
-                args.existing_backups,
-                args.settings('backup.max_full_backups', cast=int, default=2)
-            )
-        except Exception as e:
-            logger.error(f'Error while deleting backup: {e}')
-            sys.exit(1)
 
 
 @main.command('list')

--- a/src/clickhouse_backup/run.py
+++ b/src/clickhouse_backup/run.py
@@ -14,7 +14,8 @@ from loguru import logger
 from clickhouse_backup.clickhouse.client import BackupTarget, Client
 from clickhouse_backup.utils.config import parse_config
 from clickhouse_backup.utils.converters import parse_file_name
-from clickhouse_backup.utils.datatypes import Backup, FullBackup, IncrementalBackup
+from clickhouse_backup.utils.datatypes import (Backup, FullBackup,
+                                               IncrementalBackup)
 from clickhouse_backup.utils.logging import setup_logging
 
 


### PR DESCRIPTION
E.g: backup has 2 TB.

if we have 2 chains and create the 3rd one. We need 6TB...
Since we have 2 chains. Just delete the older one and then create the backup.
If the backup fails we still have the newer chain.